### PR TITLE
feat(CX-215): add first name search to find owners form

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -99,9 +99,13 @@ class OwnerController {
 		if (lastName == null) {
 			lastName = ""; // empty string signifies broadest possible search
 		}
+		String firstName = owner.getFirstName();
+		if (firstName == null) {
+			firstName = ""; // empty string signifies broadest possible search
+		}
 
-		// find owners by last name
-		Page<Owner> ownersResults = findPaginatedForOwnersLastName(page, lastName);
+		// find owners by first name and last name
+		Page<Owner> ownersResults = findPaginatedForOwners(page, firstName, lastName);
 		if (ownersResults.isEmpty()) {
 			// no owners found
 			result.rejectValue("lastName", "notFound", "not found");
@@ -115,6 +119,8 @@ class OwnerController {
 		}
 
 		// multiple owners found
+		model.addAttribute("firstName", firstName);
+		model.addAttribute("lastName", lastName);
 		return addPaginationModel(page, model, ownersResults);
 	}
 
@@ -127,10 +133,10 @@ class OwnerController {
 		return "owners/ownersList";
 	}
 
-	private Page<Owner> findPaginatedForOwnersLastName(int page, String lastname) {
+	private Page<Owner> findPaginatedForOwners(int page, String firstName, String lastName) {
 		int pageSize = 5;
 		Pageable pageable = PageRequest.of(page - 1, pageSize);
-		return owners.findByLastNameStartingWith(lastname, pageable);
+		return owners.findByFirstNameStartingWithAndLastNameStartingWith(firstName, lastName, pageable);
 	}
 
 	@GetMapping("/owners/{ownerId}/edit")

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
@@ -45,6 +45,18 @@ public interface OwnerRepository extends JpaRepository<Owner, Integer> {
 	Page<Owner> findByLastNameStartingWith(String lastName, Pageable pageable);
 
 	/**
+	 * Retrieve {@link Owner}s from the data store by first name and last name, returning
+	 * all owners whose first name <i>starts</i> with the given first name and whose last
+	 * name <i>starts</i> with the given last name.
+	 * @param firstName Value to search for in first name
+	 * @param lastName Value to search for in last name
+	 * @return a Collection of matching {@link Owner}s (or an empty Collection if none
+	 * found)
+	 */
+	Page<Owner> findByFirstNameStartingWithAndLastNameStartingWith(String firstName, String lastName,
+			Pageable pageable);
+
+	/**
 	 * Retrieve an {@link Owner} from the data store by id.
 	 * <p>
 	 * This method returns an {@link Optional} containing the {@link Owner} if found. If

--- a/src/main/resources/templates/owners/findOwners.html
+++ b/src/main/resources/templates/owners/findOwners.html
@@ -8,6 +8,14 @@
 
   <form th:object="${owner}" th:action="@{/owners}" method="get" class="form-horizontal" id="search-owner-form">
     <div class="form-group">
+      <div class="control-group" id="firstNameGroup">
+        <label class="col-sm-2 control-label" th:text="#{firstName}">First name </label>
+        <div class="col-sm-10">
+          <input class="form-control" th:field="*{firstName}" size="30" maxlength="80" />
+        </div>
+      </div>
+    </div>
+    <div class="form-group">
       <div class="control-group" id="lastNameGroup">
         <label class="col-sm-2 control-label" th:text="#{lastName}">Last name </label>
         <div class="col-sm-10">

--- a/src/main/resources/templates/owners/ownersList.html
+++ b/src/main/resources/templates/owners/ownersList.html
@@ -32,26 +32,26 @@
     <span th:text="#{pages}">Pages:</span>
     <span>[</span>
     <span th:each="i: ${#numbers.sequence(1, totalPages)}">
-      <a th:if="${currentPage != i}" th:href="@{'/owners?page=' + ${i}}">[[${i}]]</a>
+      <a th:if="${currentPage != i}" th:href="@{/owners(page=${i},firstName=${firstName},lastName=${lastName})}">[[${i}]]</a>
       <span th:unless="${currentPage != i}">[[${i}]]</span>
     </span>
     <span>]&nbsp;</span>
     <span>
-      <a th:if="${currentPage > 1}" th:href="@{'/owners?page=1'}" th:title="#{first}" class="fa fa-fast-backward"></a>
+      <a th:if="${currentPage > 1}" th:href="@{/owners(page=1,firstName=${firstName},lastName=${lastName})}" th:title="#{first}" class="fa fa-fast-backward"></a>
       <span th:unless="${currentPage > 1}" th:title="#{first}" class="fa fa-fast-backward"></span>
     </span>
     <span>
-      <a th:if="${currentPage > 1}" th:href="@{'/owners?page=__${currentPage - 1}__'}" th:title="#{previous}"
+      <a th:if="${currentPage > 1}" th:href="@{/owners(page=${currentPage - 1},firstName=${firstName},lastName=${lastName})}" th:title="#{previous}"
         class="fa fa-step-backward"></a>
       <span th:unless="${currentPage > 1}" th:title="#{previous}" class="fa fa-step-backward"></span>
     </span>
     <span>
-      <a th:if="${currentPage < totalPages}" th:href="@{'/owners?page=__${currentPage + 1}__'}" th:title="#{next}"
+      <a th:if="${currentPage < totalPages}" th:href="@{/owners(page=${currentPage + 1},firstName=${firstName},lastName=${lastName})}" th:title="#{next}"
         class="fa fa-step-forward"></a>
       <span th:unless="${currentPage < totalPages}" th:title="#{next}" class="fa fa-step-forward"></span>
     </span>
     <span>
-      <a th:if="${currentPage < totalPages}" th:href="@{'/owners?page=__${totalPages}__'}" th:title="#{last}"
+      <a th:if="${currentPage < totalPages}" th:href="@{/owners(page=${totalPages},firstName=${firstName},lastName=${lastName})}" th:title="#{last}"
         class="fa fa-fast-forward"></a>
       <span th:unless="${currentPage < totalPages}" th:title="#{last}" class="fa fa-fast-forward"></span>
     </span>

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java
@@ -91,7 +91,8 @@ class OwnerControllerTests {
 	void setup() {
 
 		Owner george = george();
-		given(this.owners.findByLastNameStartingWith(eq("Franklin"), any(Pageable.class)))
+		given(this.owners.findByFirstNameStartingWithAndLastNameStartingWith(eq(""), eq("Franklin"),
+				any(Pageable.class)))
 			.willReturn(new PageImpl<>(List.of(george)));
 
 		given(this.owners.findById(TEST_OWNER_ID)).willReturn(Optional.of(george));
@@ -142,15 +143,40 @@ class OwnerControllerTests {
 	@Test
 	void testProcessFindFormSuccess() throws Exception {
 		Page<Owner> tasks = new PageImpl<>(List.of(george(), new Owner()));
-		when(this.owners.findByLastNameStartingWith(anyString(), any(Pageable.class))).thenReturn(tasks);
+		when(this.owners.findByFirstNameStartingWithAndLastNameStartingWith(anyString(), anyString(),
+				any(Pageable.class)))
+			.thenReturn(tasks);
 		mockMvc.perform(get("/owners?page=1")).andExpect(status().isOk()).andExpect(view().name("owners/ownersList"));
 	}
 
 	@Test
 	void testProcessFindFormByLastName() throws Exception {
 		Page<Owner> tasks = new PageImpl<>(List.of(george()));
-		when(this.owners.findByLastNameStartingWith(eq("Franklin"), any(Pageable.class))).thenReturn(tasks);
+		when(this.owners.findByFirstNameStartingWithAndLastNameStartingWith(eq(""), eq("Franklin"),
+				any(Pageable.class)))
+			.thenReturn(tasks);
 		mockMvc.perform(get("/owners?page=1").param("lastName", "Franklin"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(view().name("redirect:/owners/" + TEST_OWNER_ID));
+	}
+
+	@Test
+	void testProcessFindFormByFirstName() throws Exception {
+		Page<Owner> tasks = new PageImpl<>(List.of(george()));
+		when(this.owners.findByFirstNameStartingWithAndLastNameStartingWith(eq("George"), eq(""), any(Pageable.class)))
+			.thenReturn(tasks);
+		mockMvc.perform(get("/owners?page=1").param("firstName", "George"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(view().name("redirect:/owners/" + TEST_OWNER_ID));
+	}
+
+	@Test
+	void testProcessFindFormByFirstNameAndLastName() throws Exception {
+		Page<Owner> tasks = new PageImpl<>(List.of(george()));
+		when(this.owners.findByFirstNameStartingWithAndLastNameStartingWith(eq("George"), eq("Franklin"),
+				any(Pageable.class)))
+			.thenReturn(tasks);
+		mockMvc.perform(get("/owners?page=1").param("firstName", "George").param("lastName", "Franklin"))
 			.andExpect(status().is3xxRedirection())
 			.andExpect(view().name("redirect:/owners/" + TEST_OWNER_ID));
 	}
@@ -158,13 +184,26 @@ class OwnerControllerTests {
 	@Test
 	void testProcessFindFormNoOwnersFound() throws Exception {
 		Page<Owner> tasks = new PageImpl<>(List.of());
-		when(this.owners.findByLastNameStartingWith(eq("Unknown Surname"), any(Pageable.class))).thenReturn(tasks);
+		when(this.owners.findByFirstNameStartingWithAndLastNameStartingWith(eq(""), eq("Unknown Surname"),
+				any(Pageable.class)))
+			.thenReturn(tasks);
 		mockMvc.perform(get("/owners?page=1").param("lastName", "Unknown Surname"))
 			.andExpect(status().isOk())
 			.andExpect(model().attributeHasFieldErrors("owner", "lastName"))
 			.andExpect(model().attributeHasFieldErrorCode("owner", "lastName", "notFound"))
 			.andExpect(view().name("owners/findOwners"));
+	}
 
+	@Test
+	void testProcessFindFormByFirstNameNoOwnersFound() throws Exception {
+		Page<Owner> tasks = new PageImpl<>(List.of());
+		when(this.owners.findByFirstNameStartingWithAndLastNameStartingWith(eq("Unknown"), eq(""), any(Pageable.class)))
+			.thenReturn(tasks);
+		mockMvc.perform(get("/owners?page=1").param("firstName", "Unknown"))
+			.andExpect(status().isOk())
+			.andExpect(model().attributeHasFieldErrors("owner", "lastName"))
+			.andExpect(model().attributeHasFieldErrorCode("owner", "lastName", "notFound"))
+			.andExpect(view().name("owners/findOwners"));
 	}
 
 	@Test


### PR DESCRIPTION
Automated implementation by Ona Agent. See the linked Linear issue [CX-215](https://linear.app/ona-team/issue/CX-215/owner-search-by-first-name) for requirements.

## Problem

The find owners form only searches by last name. When multiple owners share a surname, there is no way to narrow results without clicking through each match.

## Changes

- **`OwnerRepository`** — Added `findByFirstNameStartingWithAndLastNameStartingWith` query method (Spring Data derives the SQL automatically)
- **`OwnerController`** — `processFindForm` now reads both `firstName` and `lastName`, defaulting each to `""` for the broadest match. Search terms are passed to the model for pagination
- **`findOwners.html`** — Added a first name input field above the existing last name field
- **`ownersList.html`** — Pagination links now preserve both `firstName` and `lastName` query parameters using Thymeleaf URL syntax
- **`OwnerControllerTests`** — Updated existing mocks to use the new repository method. Added 3 new tests: first-name-only search, combined first+last search, and first-name-only no-results

## Behavior

- Both fields are optional. Leaving either blank matches all values for that field
- Empty form still returns all owners (backward compatible)
- No schema changes needed — `first_name` column already exists in all DB variants (H2, MySQL, Postgres)

## Test results

✅ 62/62 tests pass (unit + integration)