### PR TITLE
Add computed age field to pets

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
@@ -16,6 +16,7 @@
 package org.springframework.samples.petclinic.owner;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -64,6 +65,17 @@ public class Pet extends NamedEntity {
 
 	public LocalDate getBirthDate() {
 		return this.birthDate;
+	}
+
+	/**
+	 * Returns the pet's age in years, computed from birthDate. Returns null if birthDate
+	 * is not set.
+	 */
+	public Integer getAge() {
+		if (this.birthDate == null) {
+			return null;
+		}
+		return Period.between(this.birthDate, LocalDate.now()).getYears();
 	}
 
 	public PetType getType() {

--- a/src/main/resources/templates/owners/ownerDetails.html
+++ b/src/main/resources/templates/owners/ownerDetails.html
@@ -51,7 +51,11 @@
           <dt th:text="#{name}">Name</dt>
           <dd th:text="${pet.name}"></dd>
           <dt th:text="#{birthDate}">Birth Date</dt>
-          <dd th:text="${#temporals.format(pet.birthDate, 'yyyy-MM-dd')}"></dd>
+          <dd>
+            <span th:text="${#temporals.format(pet.birthDate, 'yyyy-MM-dd')}"></span>
+            <span th:if="${pet.age != null}" class="text-muted"
+              th:text="'(' + ${pet.age} + (${pet.age == 1} ? ' year old)' : ' years old)')"></span>
+          </dd>
           <dt th:text="#{type}">Type</dt>
           <dd th:text="${pet.type}"></dd>
         </dl>


### PR DESCRIPTION
Derive pet age from `birthDate` and display it on the owner details page next to the birth date.

### Changes

- **`Pet.java`** — Add `getAge()` method that computes age in years via `Period.between(birthDate, LocalDate.now())`. Returns `null` if `birthDate` is unset. Not persisted.
- **`ownerDetails.html`** — Show `(N years old)` inline after the birth date, with singular/plural handling and `text-muted` styling.