### PR TITLE
CVE jackson-core DoS & logback arbitrary class instantiation Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,13 @@
     <maven-checkstyle.version>3.6.0</maven-checkstyle.version>
     <nohttp-checkstyle.version>0.0.11</nohttp-checkstyle.version>
     <spring-format.version>0.0.47</spring-format.version>
+
+    <!-- CVE-2026-29062 & GHSA-72hv-8253-57qq: jackson-core DoS vulnerabilities -->
+    <jackson-bom.version>3.1.0</jackson-bom.version>
+    <!-- jackson 3.1.0 requires jackson-annotations 2.21+ -->
+    <jackson-2-bom.version>2.21.2</jackson-2-bom.version>
+    <!-- CVE-2026-1225: logback-core arbitrary class instantiation via malicious config -->
+    <logback.version>1.5.25</logback.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
## Summary

Resolves 3 CVEs found by Trivy filesystem scan by overriding Spring Boot managed dependency versions in `pom.xml`.

## CVEs Addressed

| CVE | Severity | Package | Version Change |
|-----|----------|---------|----------------|
| CVE-2026-29062 | **HIGH** | `tools.jackson.core:jackson-core` | 3.0.3 → 3.1.0 |
| GHSA-72hv-8253-57qq | **HIGH** | `tools.jackson.core:jackson-core` | 3.0.3 → 3.1.0 |
| CVE-2026-1225 | **LOW** | `ch.qos.logback:logback-core` | 1.5.22 → 1.5.25 |

## Changes

- **`jackson-bom.version`**: 3.0.3 → 3.1.0 — fixes both jackson-core DoS vulnerabilities (excessive JSON nesting and async parser number length bypass)
- **`jackson-2-bom.version`**: 2.20.1 → 2.21.2 — required because jackson-databind 3.1.0 depends on `jackson-annotations:2.21+` (adds `JsonSerializeAs` class absent in 2.20.x)
- **`logback.version`**: 1.5.22 → 1.5.25 — fixes arbitrary class instantiation via malicious `logback.xml` configuration

## Verification

- Trivy rescan: **0 vulnerabilities**
- Test suite: **59 tests passed, 0 failures**